### PR TITLE
--use-mirrors not avaliable in pip 7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "0.10"
 before_install:
-  - sudo pip install --use-mirrors -r test-infra/requirements.txt
+  - sudo pip install -r test-infra/requirements.txt
   - rvm use 1.9.3 --fuzzy
 install:
   - npm install -g grunt-cli


### PR DESCRIPTION
--use-mirrors not avaliable in pip 7+, see details: https://pip.pypa.io/en/stable/news/

7.0.0 (2015-05-21): BACKWARD INCOMPATIBLE Removed the deprecated --mirror, --use-mirrors, and -M options.
